### PR TITLE
Social example updated for >= 3.0 express stormpath.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/stormpath/stormpath-express-social-unification-example#readme",
   "dependencies": {
     "express": "^4.13.3",
-    "express-stormpath": "^2.3.4",
+    "express-stormpath": "^3.0.1",
     "node-uuid": "^1.4.7"
   }
 }

--- a/server.js
+++ b/server.js
@@ -14,78 +14,74 @@ app.use(stormpath.init(app, { website: true }));
 function unify(req, res, next) {
   var application = app.get('stormpathApplication');
 
-  if (!req.user) {
-    return next();
-  }
-
-  req.user.getProviderData(function(err, data) {
-    if (err) {
-      return next(err);
-    }
-
-    if (data.providerId === 'stormpath') {
+  helpers.getUser(req, res, function() {
+    if (!req.user) {
       return next();
     }
 
-    // If this user was literally logged in on this SAME request, we cannot do
-    // anything, so just continue onwards and force a page reload.
-    if (res.headerSent) {
-      return res.redirect(req.originalUrl);
-    }
-
-    // We found a social user, so we'll attempt to look up their Cloud
-    // directory account.
-    application.getAccounts({ email: req.user.email }, function(err, accounts) {
+    req.user.getProviderData(function(err, data) {
       if (err) {
         return next(err);
       }
-
-      var cloudAccount;
-      accounts.each(function(account, cb) {
-        account.getProviderData(function(err, data) {
-          if (err) {
-            return cb(err);
-          }
-
-          if (data.providerId === 'stormpath') {
-            cloudAccount = account;
-          }
-
-          cb();
-        });
-      }, function(err) {
+      if (data.providerId === 'stormpath') {
+        return next();
+      }
+      // If this user was literally logged in on this SAME request, we cannot do
+      // anything, so just continue onwards and force a page reload.
+      if (res.headerSent) {
+        return res.redirect(req.originalUrl);
+      }
+      // We found a social user, so we'll attempt to look up their Cloud
+      // directory account.
+      application.getAccounts({ email: req.user.email }, function(err, accounts) {
         if (err) {
           return next(err);
         }
-
-        // Swap session.
-        if (cloudAccount) {
-          res.locals.user = cloudAccount;
-          req.user = cloudAccount;
-          helpers.createIdSiteSession(req.user, req, res);
-
-          return next();
-        }
-
-        // If we get here, it means we need to create a new Cloud account for
-        // this social user -- so, let's do it!
-        application.createAccount({
-          status: req.user.status,
-          givenName: req.user.givenName,
-          surname: req.user.surname,
-          middleName: req.user.middleName,
-          email: req.user.email,
-          password: uuid.v4() + uuid.v4().toUpperCase()
-        }, { registrationWorkflowEnabled: false }, function(err, account) {
+        var cloudAccount;
+        accounts.each(function(account, cb) {
+          account.getProviderData(function(err, data) {
+            if (err) {
+              return cb(err);
+            }
+            if (data.providerId === 'stormpath') {
+              cloudAccount = account;
+            }
+            cb();
+          });
+        }, function(err) {
           if (err) {
             return next(err);
           }
 
-          res.locals.user = account;
-          req.user = account;
-          helpers.createIdSiteSession(account, req, res);
+          // Swap session.
+          if (cloudAccount) {
+            res.locals.user = cloudAccount;
+            req.user = cloudAccount;
+            helpers.createStormpathSession(req.user, req, res, function(err) {
+              return next();
+            });
+          } else {
+            // If we get here, it means we need to create a new Cloud account for
+            // this social user -- so, let's do it!
+            application.createAccount({
+              status: req.user.status,
+              givenName: req.user.givenName,
+              surname: req.user.surname,
+              middleName: req.user.middleName,
+              email: req.user.email,
+              password: uuid.v4() + uuid.v4().toUpperCase()
+            }, { registrationWorkflowEnabled: false }, function(err, account) {
+              if (err) {
+                return next(err);
+              }
 
-          next();
+              res.locals.user = account;
+              req.user = account;
+              helpers.createStormpathSession(account, req, res, function(err) {
+                next();
+              });
+            });
+          }
         });
       });
     });


### PR DESCRIPTION
Updated social unification example to work with express-stormpath >= 3.0.

Main difference is req.user is no longer explicitly availabe on every request,
so the unify middleware must call this helper explicitly.o

Also, the session function changed names and requires a callback now.
